### PR TITLE
지출 내역 목록 페이지 달력 수정

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,9 +5,6 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="StartActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/example/jaringobi/model/CalendarItem.kt
+++ b/app/src/main/java/com/example/jaringobi/model/CalendarItem.kt
@@ -2,6 +2,6 @@ package com.example.jaringobi.model
 
 sealed class CalendarItem {
     data class Weekday(val name: String) : CalendarItem()
-
     data class Date(val day: Int) : CalendarItem()
+    object Empty : CalendarItem()
 }

--- a/app/src/main/java/com/example/jaringobi/view/expenseListPage/CalendarAdapter.kt
+++ b/app/src/main/java/com/example/jaringobi/view/expenseListPage/CalendarAdapter.kt
@@ -7,116 +7,93 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.example.jaringobi.R
 import com.example.jaringobi.databinding.ItemCalendarDayBinding
+import com.example.jaringobi.databinding.ItemCalendarWeekdayBinding
 import com.example.jaringobi.model.CalendarItem
 
-/**
- * RecyclerView를 사용하여 날짜 목록을 표시
- *
- * @param items
- * @param onDateClick 날짜 클릭 이벤트를 처리하는 콜백 함수
- */
 class CalendarAdapter(
     private val items: List<CalendarItem>,
-    private val onDateClick: (Int) -> Unit,
+    private val onDateClick: (Int) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private var selectedPosition = RecyclerView.NO_POSITION
 
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            R.layout.item_calendar_day -> {
+                val binding = ItemCalendarDayBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                CalendarViewHolder(binding)
+            }
+            R.layout.item_calendar_weekday -> {
+                val binding = ItemCalendarWeekdayBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                WeekdayViewHolder(binding)
+            }
+            else -> throw IllegalArgumentException("Invalid view type")
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is CalendarViewHolder -> holder.bind(items[position] as? CalendarItem.Date, position)
+            is WeekdayViewHolder -> holder.bind(items[position] as CalendarItem.Weekday)
+        }
+    }
+
     override fun getItemViewType(position: Int): Int {
         return when (items[position]) {
-            is CalendarItem.Weekday -> VIEW_TYPE_WEEKDAY
-            is CalendarItem.Date -> VIEW_TYPE_DATE
-        }
-    }
-
-    override fun onCreateViewHolder(
-        parent: ViewGroup,
-        viewType: Int,
-    ): RecyclerView.ViewHolder {
-        return when (viewType) {
-            VIEW_TYPE_WEEKDAY ->
-                WeekdayViewHolder(
-                    ItemCalendarDayBinding.inflate(LayoutInflater.from(parent.context), parent, false),
-                )
-
-            VIEW_TYPE_DATE ->
-                DateViewHolder(
-                    ItemCalendarDayBinding.inflate(LayoutInflater.from(parent.context), parent, false),
-                )
-
-            else -> throw IllegalArgumentException("Unknown view type")
-        }
-    }
-
-    override fun onBindViewHolder(
-        holder: RecyclerView.ViewHolder,
-        position: Int,
-    ) {
-        when (holder) {
-            is WeekdayViewHolder -> holder.bind((items[position] as CalendarItem.Weekday).name)
-            is DateViewHolder -> holder.bind((items[position] as CalendarItem.Date).day, position)
+            is CalendarItem.Date -> R.layout.item_calendar_day
+            is CalendarItem.Weekday -> R.layout.item_calendar_weekday
+            is CalendarItem.Empty -> R.layout.item_calendar_day
         }
     }
 
     override fun getItemCount() = items.size
 
-    inner class WeekdayViewHolder(private val binding: ItemCalendarDayBinding) :
+    inner class CalendarViewHolder(private val binding: ItemCalendarDayBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(weekday: String) {
-            binding.calendarDayText.text = weekday
-            binding.calendarDayText.setTextColor(
-                ContextCompat.getColor(binding.root.context, R.color.default_text_color),
-            )
-        }
-    }
+        fun bind(item: CalendarItem.Date?, position: Int) {
+            if (item != null) {
+                binding.calendarDayText.text = item.day.toString()
+                setWeekendColor(binding.calendarDayText, position)
+                setSelectionBackground(position)
 
-    inner class DateViewHolder(private val binding: ItemCalendarDayBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-        fun bind(
-            day: Int,
-            position: Int,
-        ) {
-            binding.calendarDayText.text = day.toString()
-            setWeekendColor(binding.calendarDayText, position)
-            setSelectionBackground(position)
-
-            binding.root.setOnClickListener {
-                onDateClick(day)
-                updateSelection(position)
+                binding.root.setOnClickListener {
+                    onDateClick(item.day)
+                    updateSelection(position)
+                }
+            } else {
+                binding.calendarDayText.text = ""
+                binding.root.setOnClickListener(null)
             }
         }
 
         private fun setSelectionBackground(position: Int) {
-            binding.calendarDayText.background =
-                if (selectedPosition == position) {
-                    ContextCompat.getDrawable(binding.root.context, R.drawable.selected_date_background)
-                } else {
-                    null
-                }
+            binding.calendarDayText.background = if (selectedPosition == position) {
+                ContextCompat.getDrawable(binding.root.context, R.drawable.selected_date_background)
+            } else {
+                null
+            }
         }
 
-        private fun setWeekendColor(
-            textView: TextView,
-            position: Int,
-        ) {
-            val dayOfWeek = (position % 7)
-            val colorResId =
-                when (dayOfWeek) {
-                    0 -> R.color.sunday_red // 일요일
-                    6 -> R.color.saturday_blue // 토요일
-                    else -> R.color.default_text_color
-                }
+        private fun setWeekendColor(textView: TextView, position: Int) {
+            val dayOfWeek = (position % 7) + 1
+            val colorResId = when (dayOfWeek) {
+                1 -> R.color.sunday_red // 일요일
+                7 -> R.color.saturday_blue // 토요일
+                else -> R.color.default_text_color
+            }
             textView.setTextColor(ContextCompat.getColor(textView.context, colorResId))
         }
 
         private fun updateSelection(newPosition: Int) {
-            notifyItemChanged(selectedPosition)
+            notifyItemChanged(selectedPosition) // 이전 선택된 항목 갱신
             selectedPosition = newPosition
-            notifyItemChanged(selectedPosition)
+            notifyItemChanged(selectedPosition) // 현재 선택된 항목 갱신
         }
     }
 
-    companion object {
-        private const val VIEW_TYPE_WEEKDAY = 0
-        private const val VIEW_TYPE_DATE = 1
+    inner class WeekdayViewHolder(private val binding: ItemCalendarWeekdayBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: CalendarItem.Weekday) {
+            binding.weekdayText.text = item.name
+        }
     }
 }

--- a/app/src/main/res/layout/item_calendar_weekday.xml
+++ b/app/src/main/res/layout/item_calendar_weekday.xml
@@ -5,13 +5,12 @@
     android:padding="8dp">
 
     <TextView
-        android:id="@+id/calendarDayText"
+        android:id="@+id/weekdayText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:layout_gravity="center"
         android:textSize="16sp"
-        android:background="?attr/selectableItemBackgroundBorderless"
         android:padding="8dp" />
 
 </FrameLayout>


### PR DESCRIPTION
- 실제 달력과 동일하게 수정
- 월 바꿈 시 clearExpensesList 메소드 호출로 지출 내역 빈 화면으로 초기화
- 특정 날자 클릭 시에만 해당하는 지출 내역 볼 수 있도록 설정